### PR TITLE
fix: allocate for received message body in all cases

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1023,12 +1023,8 @@ func (cn *conn) recvMessage(r *readBuf) (byte, error) {
 	// read the type and length of the message that follows
 	t := x[0]
 	n := int(binary.BigEndian.Uint32(x[1:])) - 4
-	var y []byte
-	if n <= len(cn.scratch) {
-		y = cn.scratch[:n]
-	} else {
-		y = make([]byte, n)
-	}
+	// work around data race https://github.com/coder/internal/issues/731
+	var y []byte = make([]byte, n)
 	_, err = io.ReadFull(cn.buf, y)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
work around for https://github.com/coder/internal/issues/731 until we can move to pgx or develop a permament fix.

The result of this fix is that pq will allocate memory for each postgres message received. Since we were already doing this for any large (~>512 bytes) results, the performance overhead is expected to be minimal, and should cause our tests to stop flaking.